### PR TITLE
CI: Fix gem release step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,11 +31,8 @@ jobs:
             echo ":rubygems_api_key: $RUBYGEMS_API_KEY" >  ~/.gem/credentials
             chmod 0600 ~/.gem/credentials
       - run:
-          name: Build gem
-          command: bundle exec rake build --trace
-      - run:
           name: Release gem
-          command: bundle exec rake release:rubygem_push --trace
+          command: bundle exec rake build release:rubygem_push --trace
   rubocop:
     executor: ruby
     steps:


### PR DESCRIPTION
💁 The Rake task in Bundler for releasing gems relies on the `build` task to set a variable for the path to the new gem. Without that the path is set to nil and the task fails.

Building and pushing the gem in one step resolves that.