### PR TITLE
Add the homepage attribute to the gem spec

### DIFF
--- a/fluent-plugin-gelf.gemspec
+++ b/fluent-plugin-gelf.gemspec
@@ -4,10 +4,11 @@ lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
-  spec.name    = "fluent-plugin-gelf"
-  spec.version = "0.2.4"
-  spec.authors = ["Funding Circle"]
-  spec.email   = ["engineering+fluent-plugin-gelf@fundingcircle.com"]
+  spec.name     = "fluent-plugin-gelf"
+  spec.version  = "0.2.4"
+  spec.authors  = ["Funding Circle"]
+  spec.email    = ["engineering+fluent-plugin-gelf@fundingcircle.com"]
+  spec.homepage = ["https://github.com/FundingCircle/fluent-plugin-gelf"]
 
   spec.summary       = "Graylog output plugin for fluentd"
   spec.description   = "Converts fluentd log events into GELF format and sends them to Graylog"


### PR DESCRIPTION
The homepage attribute is used to fulfill link in the Name collumn at the plugin list https://www.fluentd.org/plugins/all .