### PR TITLE
fix IndexError: string not matched

### DIFF
--- a/fluent-plugin-gelf.gemspec
+++ b/fluent-plugin-gelf.gemspec
@@ -5,7 +5,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name    = "fluent-plugin-gelf"
-  spec.version = "0.2.4"
+  spec.version = "0.2.5"
   spec.authors = ["Funding Circle"]
   spec.email   = ["engineering+fluent-plugin-gelf@fundingcircle.com"]
 
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_development_dependency "oj", "~> 3.3.10"
-  spec.add_development_dependency "bundler", "~> 2.1.4"
+  spec.add_development_dependency "bundler", "~> 2.2.32"
   spec.add_development_dependency "rake", ">= 12.3.3"
   spec.add_development_dependency "test-unit", "~> 3.0"
   spec.add_development_dependency "test-unit-rr", "~> 1.0.5"

--- a/lib/fluent/plugin/gelf_plugin_util.rb
+++ b/lib/fluent/plugin/gelf_plugin_util.rb
@@ -41,7 +41,7 @@ module Fluent
       json["host"] = record["host"] # preserve host
       record.delete(key)
       record.merge(json)
-    rescue Oj::ParseError
+    rescue Oj::ParseError, EncodingError, IndexError
       record
     end
 

--- a/test/fixtures/quoted_string.json
+++ b/test/fixtures/quoted_string.json
@@ -1,0 +1,31 @@
+{
+  "event": {
+    "tag": "docker.9ee424d12013",
+    "time": "2022-02-03 16:17:23.034547719",
+    "record": {
+      "container_id": "9ee424d120137232b53bbaa678097b71e50e69de148e2ee4b77a94795e561862",
+      "container_name": "/mesos-b3e48670-9810-4c80-93dc-e45ffd485a00",
+      "source": "stdout",
+      "log": "    \"${catalina.home}/lib/*.jar\"",
+      "mesos_framework": "marathon",
+      "app": "jira",
+      "mesos_task_id": "jira.instance-ab27d9c9-850c-11ec-a8d1-024295fdd3e6._app.1",
+      "host": "mesosslave-private-04610d00f6a6254ec",
+      "msec": "512"
+    }
+  },
+  "expected": {
+    "timestamp": 1643905043.035,
+    "_fluentd_tag": "docker.9ee424d12013",
+    "_container_id": "9ee424d120137232b53bbaa678097b71e50e69de148e2ee4b77a94795e561862",
+    "_container_name": "/mesos-b3e48670-9810-4c80-93dc-e45ffd485a00",
+    "_source": "stdout",
+    "_mesos_framework": "marathon",
+    "_app": "jira",
+    "_mesos_task_id": "jira.instance-ab27d9c9-850c-11ec-a8d1-024295fdd3e6._app.1",
+    "host": "mesosslave-private-04610d00f6a6254ec",
+    "_msec": "512",
+    "short_message": "    \"${catalina.home}/lib/*.jar\"",
+    "level": 6
+  }
+}


### PR DESCRIPTION
If a log line is a quoted string [Oj manages to load it](https://github.com/FundingCircle/fluent-plugin-gelf/blob/master/lib/fluent/plugin/gelf_plugin_util.rb#L39) and errors with `IndexError: string not matched` [here](https://github.com/FundingCircle/fluent-plugin-gelf/blob/master/lib/fluent/plugin/gelf_plugin_util.rb#L41).

```ruby
[1] pry(main)> require "oj"
=> true
[2] pry(main)> json = Oj.load("\"test\"")
=> "test"
[3] pry(main)> json["host"] = "host"
IndexError: string not matched
from (pry):4:in `[]='
```